### PR TITLE
ci: add least-privilege permissions to release-extension workflow

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -24,6 +24,9 @@ on:  # yamllint disable-line rule:truthy
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   extension:
     name: Extension Hook (Default No-op)


### PR DESCRIPTION
## Description

Add explicit least-privilege workflow permissions to `release-extension.yml`. This workflow is listed in `PRESERVE_FILES` during smoke-test re-sync, so the upstream #562 fix does not auto-propagate; this PR applies the same `contents: read` default directly in the smoke-test repo (refs #568, #562).

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.github/workflows/release-extension.yml`**
  - Add top-level `permissions: contents: read` so the reusable extension hook runs with least privilege instead of inheriting broader defaults

## Changelog Entry

No changelog needed — internal CI permissions tweak with no user-visible behavior change.

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow permissions only; no runtime behavior change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

`release-extension.yml` is preserved on smoke-test re-sync (`PRESERVE_FILES` in upstream `init-workspace.sh`), so this one-time direct fix is required alongside the template change tracked in upstream #562.

Refs: #568, #562
