### PR TITLE
fix(ci): seed Unreleased entry so dispatch prepare-release can run (target main)

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -253,6 +253,41 @@ jobs:
             exit 1
           fi
 
+      - name: Seed CHANGELOG Unreleased entry for release validation
+        env:
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # The smoke-test repo is a fixture: it has no hand-authored changelog
+          # entries, but each release freeze resets Unreleased to empty and the
+          # downstream prepare-release gate requires Unreleased to have content.
+          # Seed a deploy entry so the release pipeline can always proceed.
+          if awk '
+            /^## Unreleased$/ {in_unreleased=1; next}
+            /^## \[/ && in_unreleased {exit 1}
+            in_unreleased && /^[[:space:]]*-[[:space:]]/ {found=1}
+            END {exit(found ? 0 : 1)}
+          ' CHANGELOG.md; then
+            echo "Unreleased already has entries; nothing to seed."
+            exit 0
+          fi
+          tmp="$(mktemp)"
+          awk -v tag="$TAG" '
+            { print }
+            /^## Unreleased$/ {in_unreleased=1; next}
+            in_unreleased && /^### Changed$/ {
+              print ""
+              print "- **Smoke-test deploy of " tag "** -- automated devcontainer release-pipeline validation; no functional changes"
+              in_unreleased=0
+            }
+          ' CHANGELOG.md > "$tmp"
+          mv "$tmp" CHANGELOG.md
+          if ! grep -q "Smoke-test deploy of ${TAG}" CHANGELOG.md; then
+            echo "ERROR: failed to seed Unreleased entry (no '### Changed' under '## Unreleased'?)"
+            exit 1
+          fi
+          echo "✓ Seeded Unreleased entry for ${TAG}"
+
       - name: Prepare deploy branch and metadata
         id: prepare_branch
         env:


### PR DESCRIPTION
## Summary

Fixes #157. The smoke-test fixture has no hand-authored changelog entries, so each release freeze resets `## Unreleased` to empty and the dispatch-driven `prepare-release` gate rejects it (`Unreleased section has no entries`). This blocked the `0.3.6-rc1` smoke-test.

This adds a **"Seed CHANGELOG Unreleased entry"** step to the deploy job in `repository-dispatch.yml`: when the scaffolded `## Unreleased` is empty it seeds a deploy bullet under `### Changed`; if entries already exist it leaves them untouched (idempotent guard).

Mirrors the upstream source-of-truth fix in vig-os/devcontainer#597 (`assets/smoke-test/.github/workflows/repository-dispatch.yml`).

## Targets `main`

`repository_dispatch` events always run workflow files from the **default branch (`main`)**, so the fix only takes effect once it is on `main`. Hence this PR targets `main` directly (single-file, workflow-only change) rather than `dev`. `dev` will pick it up via the normal `sync-main-to-dev` flow.

No `CHANGELOG.md` change: the smoke-test repo's `CHANGELOG.md` is overwritten by the install/scaffold on every deploy, so a committed entry here would be transient and meaningless. The seed step operates on the scaffolded changelog at deploy time.

## Verification

The seeding awk was validated against an empty-Unreleased fixture: it seeds correctly, leaves dated sections untouched, and the result passes the `prepare-release` gate. End-to-end is exercised by the next dispatch / RC once this is on `main`.

Refs: #157
