### PR TITLE
chore: reset 0.3.7 changelog state on dev for smoke-test re-dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,32 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.3.7] - TBD
-
-### Changed
-
-- **Smoke-test deploy of 0.3.7** -- automated devcontainer release-pipeline validation; no functional changes
-
-## [0.3.7](https://github.com/vig-os/devcontainer/releases/tag/0.3.7) - 2026-06-22
-
-### Changed
-
-- **Consolidate Renovate dependency updates (588, 589, 606, 607)** ([#588](https://github.com/vig-os/devcontainer/pull/588), [#589](https://github.com/vig-os/devcontainer/pull/589), [#606](https://github.com/vig-os/devcontainer/pull/606), [#607](https://github.com/vig-os/devcontainer/pull/607))
-  - Update `actions/checkout` to `v7.0.0`, `taiki-e/install-action` digest to `ab08a3b`, `astral-sh/setup-uv` to `0.11.23`, and the `aquasecurity/trivy-action` scanner to `v0.71.2`
-  - Bump Python deps: `pytest` 9.1.1, `ruff` 0.15.18 (root); `numpy` 2.5.0, `scipy` 1.18.0 (workspace template); lockfile refreshed
-
-### Fixed
-
-- **Prune RC draft pre-releases in promote cleanup** ([#600](https://github.com/vig-os/devcontainer/issues/600))
-  - Cleanup now deletes `X.Y.Z-rcN` draft pre-releases (and their now-orphaned tags); guarded to never touch published releases
-
-### Security
-
-- **Consolidate container-image vulnerability scanning to a single source of truth** ([#604](https://github.com/vig-os/devcontainer/issues/604))
-  - PR CI Trivy is now a blocking gate only (fail on fixable HIGH/CRITICAL) and no longer uploads SARIF to the Security tab
-  - The nightly scheduled scan of the published `:latest` image (`container-image-latest`) is now the single authoritative scan for the GitHub Security tab, ending duplicate/stale alert categories
-  - Dismissed orphaned `container-image-scheduled` and stale `container-image` code-scanning alerts that could no longer auto-close
-
 ## [0.3.6](https://github.com/vig-os/devcontainer/releases/tag/0.3.6) - 2026-06-19
 
 ### Changed


### PR DESCRIPTION
## Summary

Removes the polluted duplicate `## [0.3.7]` sections from `dev`'s CHANGELOG (a stray
`## [0.3.7] - TBD` stacked above a prematurely-dated `## [0.3.7](…) - 2026-06-22`),
restoring a clean empty `## Unreleased` above `## [0.3.6]`.

## Why

Recovery for the wedged 0.3.7 smoke-test gate (see #169). With the stale `[0.3.7]`
content present, the `deploy` idempotency check skips re-seeding `Unreleased` and/or
`prepare-changelog prepare` stacks another heading, so a re-dispatched final pass
cannot produce the `## [0.3.7] - TBD` placeholder that `release-core` validation
requires. This reset lets a fresh final dispatch recreate the entry cleanly.

The stale `release/0.3.7` branch was also deleted so `prepare-release` recreates it.

Refs: #169