### PR TITLE
fix(ci): idempotent dispatch templates across candidate→final

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -197,6 +197,11 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
+          # Normalize any dated `## [X.Y.Z]` heading left by a prior candidate→final
+          # pass on this base version back to `- TBD` before freezing, so prepare/
+          # release stay idempotent on a reused release branch (#612). No-op when
+          # the heading is already TBD or absent.
+          prepare-changelog reset-version "$VERSION" CHANGELOG.md
           prepare-changelog prepare "$VERSION" CHANGELOG.md
 
       - name: Extract CHANGELOG content for PR body

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -282,7 +282,15 @@ jobs:
             }
           ' CHANGELOG.md > "$tmp"
           mv "$tmp" CHANGELOG.md
-          if ! grep -q "Smoke-test deploy of ${TAG}" CHANGELOG.md; then
+          # Verify the bullet landed inside Unreleased specifically (#612): a
+          # whole-file grep can be satisfied by a stale bullet left in a prior
+          # `## [X.Y.Z]` section, masking an un-seeded Unreleased.
+          if ! awk -v tag="$TAG" '
+            /^## Unreleased$/ {in_unreleased=1; next}
+            /^## \[/ && in_unreleased {in_unreleased=0}
+            in_unreleased && index($0, "Smoke-test deploy of " tag) {found=1}
+            END {exit(found ? 0 : 1)}
+          ' CHANGELOG.md; then
             echo "ERROR: failed to seed Unreleased entry (no '### Changed' under '## Unreleased'?)"
             exit 1
           fi


### PR DESCRIPTION
## Description

Sync the candidate→final idempotency fixes from `vig-os/devcontainer` (upstream
issue #612) into this repo's workflow templates, so a base version `X.Y.Z`
exercised by both a candidate (`X.Y.Z-rcN`) and a final (`X.Y.Z`) pass no longer
fails downstream `release-core` validation (`does not contain '## [X.Y.Z] - TBD'`)
and no longer needs manual CHANGELOG recovery (as happened for 0.3.7).

These two files are the parts of the fix that do **not** arrive automatically:
`repository-dispatch.yml` is the `repository_dispatch` listener that GitHub runs
from this repo's default branch (`main`), so it must be promoted here directly.

## Changes

- **`repository-dispatch.yml`** — scope the deploy-seed verification to the
  `## Unreleased` section (awk) so a bullet stranded in a stale `[X.Y.Z]` section
  can no longer satisfy the check and mask an un-seeded Unreleased.
- **`prepare-release.yml`** — run `prepare-changelog reset-version` before
  `prepare` to normalize a dated `## [X.Y.Z]` heading back to `- TBD` at freeze
  time (idempotent; no-op when already TBD or absent).

The matching Python primitives (`prepare-changelog` idempotent `finalize`,
`prepare` dedup, and the new `reset-version` command) ship in the devcontainer
image and reach this repo via the installer at the release tag.

## Testing

- `pre-commit run` passes on both files.
- Validated upstream end-to-end via CLI smoke (prepare → finalize → reset-version
  → re-prepare → finalize twice) producing a single dated heading with no leftover
  `TBD`; and confirmed the scoped awk rejects a stale-section bullet while a
  properly-seeded Unreleased passes.

## Notes

This is the downstream half of `vig-os/devcontainer#612` (merged there as #614).
Acceptance: after this merges and the next devcontainer release ships, run
`publish-candidate` then `finalize-release` on the same base version and confirm
"Release Core / Validate Release Core" is green.

Refs: #169
