### PR TITLE
build(deps): relax requires-python to >=3.14,<3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Relaxed `requires-python` to `>=3.14,<3.15`** ([vig-os/devcontainer#737](https://github.com/vig-os/devcontainer/issues/737))
+  - The exact `==3.14.6` pin was unsatisfiable against the Nix devcontainer image's pinned CPython (3.14.4), so `uv sync` failed in-container. Matches the devcontainer's own range-pin convention; `uv.lock` remains the reproducibility anchor (`uv sync --frozen` stays consistent).
+
 ### Security
 
 ## [0.3.9](https://github.com/vig-os/devcontainer-smoke-test/releases/tag/0.3.9) - 2026-06-23

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "devcontainer_smoke_test"
 version = "0.1.0"
 description = "devcontainer_smoke_test project"
-requires-python = "==3.14.6"
+requires-python = ">=3.14,<3.15"
 dependencies = []
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = "==3.14.6"
+requires-python = ">=3.14,<3.15"
 resolution-markers = [
     "sys_platform == 'win32'",
     "sys_platform == 'emscripten'",


### PR DESCRIPTION
The exact `==3.14.6` pin is unsatisfiable against the Nix devcontainer image's pinned CPython (3.14.4), so `uv sync` fails in-container. Relax to the range the devcontainer itself adopted; `uv.lock` stays consistent (`uv sync --frozen` passes).

Resolves the consumer side of vig-os/devcontainer#737.