### PR TITLE
fix: install pytest via dependency-group for groups-only sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,6 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = [
-  "pytest==9.1.1",
-  "pytest-cov==7.1.0",
   "ipykernel==7.3.0",
   "jupyter==1.1.1",
 ]
@@ -28,7 +26,7 @@ build-backend = "hatchling.build"
 packages = ["src/devcontainer_smoke_test"]
 
 [dependency-groups]
-dev = ["hatchling==1.30.1", "rich==15.0.0"]
+dev = ["hatchling==1.30.1", "rich==15.0.0", "pytest==9.1.1", "pytest-cov==7.1.0"]
 
 [tool.uv]
 constraint-dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -379,15 +379,11 @@ all = [
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "pandas" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
     { name = "scipy" },
 ]
 dev = [
     { name = "ipykernel" },
     { name = "jupyter" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
 ]
 science = [
     { name = "matplotlib" },
@@ -399,6 +395,8 @@ science = [
 [package.dev-dependencies]
 dev = [
     { name = "hatchling" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "rich" },
 ]
 
@@ -410,8 +408,6 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'science'", specifier = "==3.11.0" },
     { name = "numpy", marker = "extra == 'science'", specifier = "==2.5.1" },
     { name = "pandas", marker = "extra == 'science'", specifier = "==3.0.4" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "scipy", marker = "extra == 'science'", specifier = "==1.18.0" },
 ]
 provides-extras = ["dev", "science", "all"]
@@ -419,6 +415,8 @@ provides-extras = ["dev", "science", "all"]
 [package.metadata.requires-dev]
 dev = [
     { name = "hatchling", specifier = "==1.30.1" },
+    { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "rich", specifier = "==15.0.0" },
 ]
 


### PR DESCRIPTION
## Problem
0.5.0's devcontainer scaffold makes the managed `just sync` **groups-only** (`uv sync --all-groups`; extras opt-in). Our `pyproject.toml` declared `pytest`/`pytest-cov` as a `[project.optional-dependencies].dev` **extra**, so once a 0.5.0 deploy overwrites `justfile.project`, `just sync` stops installing them and `just test` fails with `Failed to spawn: pytest`.

This failed the upstream smoke-test for `0.5.0-rc1` (deploy PR CI 'Tests' red → deploy PR never auto-merges → upstream dispatch fails; vig-os/devcontainer#943).

## Fix
Move `pytest`/`pytest-cov` to `[dependency-groups].dev` (PEP 735) so the default groups-only sync installs them. Regenerate `uv.lock` (pytest/pytest-cov shed their `extra == 'dev'` marker; no version change). Science/jupyter extras stay opt-in.

## Verification (local, Python 3.14.4 / uv 0.11.25)
- `uv sync --all-groups` now installs `pytest==9.1.1`, `pytest-cov==7.1.0`
- `uv run pytest` → 2 passed
- `prek run --all-files` green

Refs: #205