### PR TITLE
refactor(rename): follow source repo rename to vig-os/devkit

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,7 +1,7 @@
 # Devcontainer Reference
 
 This folder contains everything VS Code needs to launch the
-[vigOS development container](https://github.com/vig-os/devcontainer) inside your project.
+[vigOS development container](https://github.com/vig-os/devkit) inside your project.
 
 - **Version**: This is an unreleased development version
 

--- a/.devcontainer/justfile.devc
+++ b/.devcontainer/justfile.devc
@@ -67,7 +67,7 @@ devc-upgrade:
         echo ""
         echo "Or use the curl method:"
         echo ""
-        echo "    curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} ."
+        echo "    curl -sSf https://raw.githubusercontent.com/vig-os/devkit/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} ."
         echo ""
         exit 1
     fi
@@ -94,11 +94,11 @@ devc-upgrade:
     echo "✓ Using $RUNTIME"
     echo ""
     echo "Note: the installer refuses upgrades on main/dev/release/* or a dirty tree."
-    echo "      Preview first:  curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} --preview ."
-    echo "      Bypass guard:   curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} --skip-preflight ."
+    echo "      Preview first:  curl -sSf https://raw.githubusercontent.com/vig-os/devkit/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} --preview ."
+    echo "      Bypass guard:   curl -sSf https://raw.githubusercontent.com/vig-os/devkit/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} --skip-preflight ."
     echo ""
     echo "Downloading and running install script..."
-    curl -sSf "https://raw.githubusercontent.com/vig-os/devcontainer/${REF}/install.sh" | bash -s -- --force "${PIN_ARGS[@]}" .
+    curl -sSf "https://raw.githubusercontent.com/vig-os/devkit/${REF}/install.sh" | bash -s -- --force "${PIN_ARGS[@]}" .
 
 # -------------------------------------------------------------------------------
 # DEVCONTAINER (host-side only)

--- a/.devcontainer/scripts/version-check.sh
+++ b/.devcontainer/scripts/version-check.sh
@@ -37,7 +37,7 @@ MUTED_UNTIL_FILE="$LOCAL_DIR/.muted-until"
 CACHE_FILE="$LOCAL_DIR/.latest-version"
 
 # API endpoint
-GITHUB_API="https://api.github.com/repos/vig-os/devcontainer/releases/latest"
+GITHUB_API="https://api.github.com/repos/vig-os/devkit/releases/latest"
 
 # Defaults
 DEFAULT_CHECK_INTERVAL=86400  # 24 hours in seconds
@@ -297,7 +297,7 @@ notify_update() {
     echo ""
     echo -e "  Or without just:"
     echo ""
-    echo -e "    curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force ."
+    echo -e "    curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --force ."
     echo ""
     echo -e "  After upgrading, rebuild the container in VS Code."
     echo ""

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://github.com/vig-os/devcontainer/tree/dev/docs
+    url: https://github.com/vig-os/devkit/tree/dev/docs
     about: Browse project documentation before opening an issue

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,7 +31,7 @@
      If no changelog update is needed, write "No changelog needed" and explain why.
      Example:
      ### Added
-     - **SSH agent forwarding** ([#42](https://github.com/vig-os/devcontainer/issues/42))
+     - **SSH agent forwarding** ([#42](https://github.com/vig-os/devkit/issues/42))
        - Forward host SSH agent into devcontainer for seamless git authentication
 -->
 

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -198,7 +198,7 @@ jobs:
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           set -euo pipefail
-          INSTALL_URL="https://raw.githubusercontent.com/vig-os/devcontainer/${TAG}/install.sh"
+          INSTALL_URL="https://raw.githubusercontent.com/vig-os/devkit/${TAG}/install.sh"
           ATTEMPT=1
           MAX_ATTEMPTS=3
           until [ "${ATTEMPT}" -gt "${MAX_ATTEMPTS}" ]; do
@@ -1069,7 +1069,7 @@ jobs:
           )"
 
           gh issue create \
-            --repo vig-os/devcontainer \
+            --repo vig-os/devkit \
             --title "Smoke-test dispatch failed for ${TAG:-unknown}" \
             --label bug \
             --body "${ISSUE_BODY}"

--- a/.vig-os
+++ b/.vig-os
@@ -18,7 +18,7 @@ DEVKIT_MODE=both
 # written back by init-workspace.sh — edit only to deliberately rename.
 DEVKIT_PROJECT=devcontainer_smoke_test
 DEVKIT_ORG=vigOS
-DEVKIT_REPO=vig-os/devcontainer-smoke-test
+DEVKIT_REPO=vig-os/devkit-smoke-test
 
 # Reserved: space-separated capability modules for the project dev-shell,
 # mirroring mkProjectShell's `modules = [ ... ]` in flake.nix (#884).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # devcontainer Smoke Test
 
 This repository is a smoke-test workspace for the
-[vig-os/devcontainer](https://github.com/vig-os/devcontainer) project.
+[vig-os/devcontainer](https://github.com/vig-os/devkit) project.
 
 Its purpose is to verify that the devcontainer template and the shipped CI
 workflow run successfully on real GitHub-hosted runners, not only in local or
@@ -35,7 +35,7 @@ This repository is intentionally minimal. It is used to:
 - **Execution/verification target**: this repository
 
 Template or workflow changes should be made in
-[`vig-os/devcontainer`](https://github.com/vig-os/devcontainer), then validated
+[`vig-os/devcontainer`](https://github.com/vig-os/devkit), then validated
 here through a normal PR run.
 
 ## Automated deploy-and-test flow
@@ -89,7 +89,7 @@ If this repository is lost or needs to be rebuilt, recreate it from the
 2. Clone it locally and run the installer with smoke-test assets enabled:
 
    ```bash
-   curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --smoke-test .
+   curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --smoke-test .
    ```
 
 3. Commit the generated files and push to `main`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ Older versions are not maintained.
 **Do not open a public GitHub issue for security vulnerabilities.**
 
 To report a vulnerability, use
-[GitHub Private Vulnerability Reporting](https://github.com/vig-os/devcontainer-smoke-test/security/advisories/new).
+[GitHub Private Vulnerability Reporting](https://github.com/vig-os/devkit-smoke-test/security/advisories/new).
 
 When reporting, please include:
 

--- a/docs/container-ci-quirks.md
+++ b/docs/container-ci-quirks.md
@@ -65,7 +65,7 @@ runtime.
 
 The shipped container workflows support **authenticated** GHCR pulls, so a
 **private** (or anonymous-rate-limited) `ghcr.io/vig-os/devcontainer` image works
-without any per-repo YAML edits ([#920](https://github.com/vig-os/devcontainer/issues/920)).
+without any per-repo YAML edits ([#920](https://github.com/vig-os/devkit/issues/920)).
 Public consumers are unaffected: the automatic `GITHUB_TOKEN` performs an
 authenticated pull of a public image, which succeeds unchanged.
 
@@ -109,5 +109,5 @@ set the GHCR_PULL_TOKEN secret / grant packages:read") from a **missing tag**
 public images when no token is provided.
 
 The broader workflow audit that this fix rides is tracked in
-[#781](https://github.com/vig-os/devcontainer/issues/781) and
-[#854](https://github.com/vig-os/devcontainer/issues/854).
+[#781](https://github.com/vig-os/devkit/issues/781) and
+[#854](https://github.com/vig-os/devkit/issues/854).


### PR DESCRIPTION
## Summary

Lockstep with the source-repo rename (`vig-os/devcontainer` → `vig-os/devkit`) and this repo's own rename (`devcontainer-smoke-test` → `devkit-smoke-test`).

Flips the back-references that don't survive GitHub's rename redirect reliably:
- **`repository-dispatch.yml`** — the `INSTALL_URL` the listener fetches (`raw.githubusercontent.com/vig-os/devkit/<tag>/install.sh`) and the `notify-failure` `--repo vig-os/devkit` target.
- **`version-check.sh`** API URL; `justfile.devc` / `.devcontainer/README.md` install refs.
- Self/source links in `README`, `SECURITY`, issue/PR templates, `docs/`, and the `.vig-os` `DEVKIT_REPO` pin.

## Preserved
The pulled devcontainer **image name is unchanged** (`ghcr.io/vig-os/devcontainer`) — no `ghcr.io` ref touched (ci.yml / resolve-image untouched).

## Note
The scaffolded workspace files also re-sync `devkit` source URLs from the renamed source template on the next smoke-test cycle; this PR makes the repo consistent immediately.

Refs: vig-os/devkit#781