### PR TITLE
ci: add direnv-mode smoke lane

### DIFF
--- a/.github/workflows/direnv-smoke.yml
+++ b/.github/workflows/direnv-smoke.yml
@@ -1,0 +1,224 @@
+name: Direnv Smoke
+
+# Direnv-mode smoke lane (Refs: vig-os/devkit#1194)
+#
+# The container-mode deploy PR (repository-dispatch.yml -> ci.yml) never runs
+# setup-devkit-toolchain's `if: inputs.mode == 'direnv'` branch, so two 1.4.0
+# blocking bugs escaped the pre-consumer gate: vig-os/devkit#1189 (the flake
+# shellHook banner corrupts GITHUB_ENV) and vig-os/devkit#1192 (install-nix-action
+# aborts on a runner with Nix already installed). This lane scaffolds a throwaway
+# `--mode direnv` workspace on a hosted runner and drives the direnv toolchain
+# path end to end (Detect host Nix -> install/configure Nix -> build dev-shell ->
+# forward shellHook env), so those code paths execute on every run.
+#
+# Why a fresh directory: install.sh refuses `--mode direnv` inside THIS repo
+# because its `.vig-os` pins `DEVKIT_MODE=both` (a mode contradiction is a hard
+# error). So the workspace is scaffolded into an empty `${GITHUB_WORKSPACE}` (no
+# checkout in the smoke job), where no `.vig-os` exists to contradict. The
+# scaffolded `.github/actions/setup-devkit-toolchain` composite is then invoked
+# from that root exactly as the managed ci.yml invokes it — same call site, same
+# inputs — so the lane validates the real shipped action, not a copy.
+#
+# Two legs force BOTH host-Nix branches of the composite:
+#   - fresh-install : no Nix on the runner  -> the install-nix-action branch runs
+#   - preinstalled  : Nix put on PATH first  -> "Detect host Nix" sees it and the
+#                     "Configure host Nix" branch runs. That is the self-hosted
+#                     DEVKIT_CI_RUNNER + preinstalled-Nix path that hit #1192,
+#                     faked here on a hosted runner so a public gate can cover it.
+#
+# NOTE (persistence): the smoke repo tree is fully regenerated on every
+# `--smoke-test` deploy (init-workspace.sh does `rsync --delete` from the devkit
+# template, then overlays `assets/smoke-test/`). A workflow that lives only here
+# is therefore wiped on the next deploy and is NOT present on the deploy PR head.
+# For this lane to persist and run on release-validation deploy PRs it must be
+# promoted into devkit `assets/smoke-test/.github/workflows/`. See the PR body.
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - dev
+      - 'release/**'
+      - main
+  workflow_dispatch:
+    inputs:
+      devkit-version:
+        description: 'Devkit tag under test (default: DEVKIT_VERSION from .vig-os)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  resolve-version:
+    name: Resolve devkit version
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - name: Checkout repository (.vig-os only)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: .vig-os
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve devkit version under test
+        id: resolve
+        env:
+          INPUT_VERSION: ${{ inputs.devkit-version }}
+        run: |
+          set -euo pipefail
+          # workflow_dispatch override wins; otherwise read DEVKIT_VERSION (or the
+          # legacy DEVCONTAINER_VERSION) from .vig-os, mirroring resolve-toolchain.
+          VERSION="${INPUT_VERSION:-}"
+          LEGACY=""
+          if [ -z "${VERSION}" ] && [ -f .vig-os ]; then
+            while IFS= read -r line || [ -n "${line:-}" ]; do
+              case "$line" in
+                DEVKIT_VERSION=*) VERSION="${line#*=}" ;;
+                DEVCONTAINER_VERSION=*) LEGACY="${line#*=}" ;;
+              esac
+            done < .vig-os
+            VERSION="${VERSION:-${LEGACY}}"
+          fi
+          # Strip surrounding whitespace and quotes.
+          VERSION="${VERSION#"${VERSION%%[![:space:]]*}"}"
+          VERSION="${VERSION%"${VERSION##*[![:space:]]}"}"
+          VERSION="${VERSION%\"}"; VERSION="${VERSION#\"}"
+          VERSION="${VERSION%\'}"; VERSION="${VERSION#\'}"
+          if ! printf '%s' "${VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$'; then
+            echo "::error::Could not resolve a valid devkit version (got '${VERSION}'). Expected X.Y.Z or X.Y.Z-rcN."
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Devkit version under test: ${VERSION}"
+
+  direnv-smoke:
+    name: Direnv smoke (${{ matrix.leg }})
+    needs: [resolve-version]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # fresh-install -> install-nix-action branch; preinstalled -> the
+        # Detect/Configure host-Nix branch (#1192).
+        leg: [fresh-install, preinstalled]
+    env:
+      DEVKIT_VERSION: ${{ needs.resolve-version.outputs.version }}
+    steps:
+      - name: Configure git identity for scaffold commit
+        run: |
+          set -euo pipefail
+          # The installer runs `git init` + an initial commit when it scaffolds an
+          # empty target; a hosted runner has no default git identity, so set one.
+          git config --global user.name "vigos-smoke-test"
+          git config --global user.email "smoke-test@vig-os.invalid"
+          git config --global commit.gpgsign false
+          git config --global init.defaultBranch main
+
+      # preinstalled leg only: put Nix on PATH BEFORE the toolchain composite runs
+      # so its "Detect host Nix" step sees it and takes the "Configure host Nix"
+      # branch instead of installing — the #1192 code path, faked on a hosted
+      # runner. The fresh-install leg skips this, leaving the composite to install.
+      - name: Fake a preinstalled-Nix runner
+        if: matrix.leg == 'preinstalled'
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342  # v31.11.0
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Scaffold a throwaway direnv workspace
+        env:
+          TAG: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Scaffold into the (empty) workspace root so the scaffolded composite at
+          # ./.github/actions/setup-devkit-toolchain is invocable below and its
+          # `nix develop` builds THIS scaffolded flake. `--mode direnv` is accepted
+          # because the fresh target has no .vig-os to contradict.
+          INSTALL_URL="https://raw.githubusercontent.com/vig-os/devkit/${TAG}/install.sh"
+          ATTEMPT=1
+          MAX_ATTEMPTS=3
+          until [ "${ATTEMPT}" -gt "${MAX_ATTEMPTS}" ]; do
+            if curl -sSf "${INSTALL_URL}" | bash -s -- --version "${TAG}" --mode direnv --smoke-test --force --docker .; then
+              break
+            fi
+            if [ "${ATTEMPT}" -eq "${MAX_ATTEMPTS}" ]; then
+              echo "ERROR: failed to download/install after ${MAX_ATTEMPTS} attempts: ${INSTALL_URL}"
+              exit 1
+            fi
+            echo "Install attempt ${ATTEMPT}/${MAX_ATTEMPTS} failed; retrying in 5s..."
+            ATTEMPT=$((ATTEMPT + 1))
+            sleep 5
+          done
+
+          # Docker-based scaffolding can leave bind-mounted files owned by root;
+          # repair ownership so the following steps can read/execute them.
+          if [ ! -r ".github/actions/setup-devkit-toolchain/action.yml" ] || \
+             { [ -e "flake.nix" ] && [ ! -r "flake.nix" ]; }; then
+            sudo chown -R "$(id -u):$(id -g)" .
+          fi
+
+          # Sanity: the direnv scaffold must ship the composite action and a
+          # repo-root flake for the dev-shell build.
+          test -f .github/actions/setup-devkit-toolchain/action.yml
+          test -f flake.nix
+          # A direnv scaffold owns no .devcontainer/ (host mode); assert it.
+          if [ -d .devcontainer ]; then
+            echo "ERROR: direnv scaffold unexpectedly contains .devcontainer/"
+            exit 1
+          fi
+
+      # The real shipped composite — same call site and inputs as the managed
+      # ci.yml. This is where #1189 (shellHook -> GITHUB_ENV forward) and #1192
+      # (host-Nix detect/configure) live.
+      - name: Set up devkit toolchain (direnv)
+        uses: ./.github/actions/setup-devkit-toolchain
+        with:
+          mode: direnv
+          devkit-version: ${{ needs.resolve-version.outputs.version }}
+          cachix-cache: ${{ vars.CACHIX_CACHE }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      # First step AFTER the composite: if #1189 corrupted GITHUB_ENV this step
+      # would fail to start. It also proves the dev-shell PATH was exported.
+      - name: Verify dev-shell toolchain on PATH
+        run: |
+          set -euo pipefail
+          echo "just:  $(command -v just)"
+          echo "prek:  $(command -v prek)"
+          just --version
+          prek --version
+
+      # The managed lint path (mirrors ci.yml's lint job): both run off the
+      # forwarded dev-shell PATH/env, exercising the direnv toolchain on real
+      # scaffolded files. `sync`/`test` are pyproject-guarded no-ops when the
+      # scaffold ships no Python project, so this lane asserts on `sync` +
+      # `precommit` (always meaningful) rather than a possibly-empty test run.
+      - name: Sync project dependencies
+        run: just sync
+
+      - name: Run pre-commit hooks
+        run: just precommit
+
+  summary:
+    name: Direnv Smoke Summary
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: [resolve-version, direnv-smoke]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          set -euo pipefail
+          echo "Resolve version: ${{ needs.resolve-version.result }}"
+          echo "Direnv smoke:    ${{ needs.direnv-smoke.result }}"
+          if [ "${{ needs.resolve-version.result }}" != "success" ] || \
+             [ "${{ needs.direnv-smoke.result }}" != "success" ]; then
+            echo "ERROR: direnv smoke lane failed"
+            exit 1
+          fi
+          echo "Direnv smoke lane passed (both legs)."

--- a/.github/workflows/direnv-smoke.yml
+++ b/.github/workflows/direnv-smoke.yml
@@ -155,12 +155,11 @@ jobs:
             sleep 5
           done
 
-          # Docker-based scaffolding can leave bind-mounted files owned by root;
-          # repair ownership so the following steps can read/execute them.
-          if [ ! -r ".github/actions/setup-devkit-toolchain/action.yml" ] || \
-             { [ -e "flake.nix" ] && [ ! -r "flake.nix" ]; }; then
-            sudo chown -R "$(id -u):$(id -g)" .
-          fi
+          # The docker scaffold writes bind-mounted files as root, so the whole
+          # tree is root-owned on a hosted runner. Repair ownership unconditionally
+          # (not just readability): `nix develop` must WRITE flake.lock, which a
+          # root-owned file/dir refuses ("Permission denied").
+          sudo chown -R "$(id -u):$(id -g)" .
 
           # Sanity: the direnv scaffold must ship the composite action and a
           # repo-root flake for the dev-shell build.

--- a/.github/workflows/direnv-smoke.yml
+++ b/.github/workflows/direnv-smoke.yml
@@ -161,6 +161,17 @@ jobs:
           # root-owned file/dir refuses ("Permission denied").
           sudo chown -R "$(id -u):$(id -g)" .
 
+          # install.sh's own host-side git setup runs BEFORE this ownership
+          # repair and fails on the still-root-owned tree (".git: Permission
+          # denied") — its git phase warns rather than aborts. Initialize the
+          # repo here instead: `prek run --all-files` needs a git work tree
+          # with tracked files.
+          if [ ! -d .git ]; then
+            git init -b main
+            git add -A
+            git commit -m "chore: initial project scaffold"
+          fi
+
           # Sanity: the direnv scaffold must ship the composite action and a
           # repo-root flake for the dev-shell build.
           test -f .github/actions/setup-devkit-toolchain/action.yml


### PR DESCRIPTION
## Summary

Adds a **direnv-mode smoke lane** (`.github/workflows/direnv-smoke.yml`) to close
the gap described in devkit **#1194**: this repo deploys the devkit in
**container mode only**, so `setup-devkit-toolchain`'s `if: inputs.mode == 'direnv'`
branch is never exercised by the pre-consumer gate. Two 1.4.0 blocking bugs
(#1189, #1192) lived on exactly that branch and only surfaced on real consumer
PRs, costing two extra RC round-trips.

The new lane scaffolds a throwaway `--mode direnv` workspace on a hosted runner
and drives the direnv toolchain path end to end
(Detect host Nix -> install/configure Nix -> build the repo flake dev-shell ->
forward the shellHook env), then runs the managed lint path (`just sync` +
`just precommit`) off the forwarded dev-shell PATH/env.

## How it exercises the #1189 / #1192 code paths

- **#1192 (install-nix-action aborts on preinstalled Nix)** — the job runs as a
  2-leg matrix that forces **both** host-Nix branches of the composite:
  - `fresh-install`: no Nix on the runner -> the `install-nix-action` branch runs.
  - `preinstalled`: Nix is put on PATH first (a hosted-runner *fake* of a
    self-hosted `DEVKIT_CI_RUNNER`) -> "Detect host Nix" sees it and the
    "Configure host Nix" branch runs — the path that hit #1192. So the
    fake-preinstalled leg **was added** (the issue's stretch option), not
    documented-out.
- **#1189 (shellHook banner corrupts GITHUB_ENV)** — the composite forwards the
  dev-shell shellHook env into `GITHUB_ENV`. If that record is corrupted, the
  *next* step fails to start. The lane runs post-composite steps
  ("Verify dev-shell toolchain", `just sync`, `just precommit`) that load
  `GITHUB_ENV` and use the forwarded PATH, so a #1189-class regression turns the
  lane red.

## Design decisions (autonomous)

1. **Fresh-directory scaffold, not in-place.** `install.sh` refuses `--mode direnv`
   inside this repo because its `.vig-os` pins `DEVKIT_MODE=both` (a mode
   contradiction is a hard error, `install.sh:576`). The lane therefore scaffolds
   into an empty `${GITHUB_WORKSPACE}` (no checkout in the smoke job), where no
   `.vig-os` exists to contradict, and invokes the **scaffolded** composite
   `./.github/actions/setup-devkit-toolchain` from that root — same call site and
   inputs as the managed `ci.yml`, so the lane validates the real shipped action.
2. **Runs `sync` + `precommit`, not `test`.** The template ships no tests and
   `just test`/`just sync` are `pyproject`-guarded; `just precommit` (prek) always
   runs and, together with `sync`, fully exercises both bug paths on real
   scaffolded files. This mirrors `ci.yml`'s **lint** job.
3. **Version selection** matches how the repo already selects the devkit under
   test: `resolve-version` reads `DEVKIT_VERSION` (or legacy
   `DEVCONTAINER_VERSION`) from `.vig-os`, with a `workflow_dispatch`
   `devkit-version` override to target a specific RC tag.
4. **No CHANGELOG entry.** This repo's `CHANGELOG.md` is a devkit-synced fixture
   with no hand-authored entries (see `repository-dispatch.yml`), reset on every
   release freeze — a manual entry would be wiped.

## Persistence finding (important follow-up for devkit)

The smoke repo's tree is **fully regenerated on every `--smoke-test` deploy**:
`init-workspace.sh:1313` does `rsync -avL --delete` from the devkit template, then
overlays `assets/smoke-test/` (only `repository-dispatch.yml`, `README.md`,
`renovate.json`). **A workflow that lives only in this repo is deleted on the next
deploy and is not present on the deploy-PR head**, so it would not run during
release validation.

For the lane to persist and gate release-validation deploy PRs, this file must be
**promoted into devkit `assets/smoke-test/.github/workflows/direnv-smoke.yml`**
(a devkit change, out of scope here per the task's read-only-devkit constraint).
This PR's value is (a) validating the lane on **real hosted runners** — the part
that cannot be unit-tested in devkit — and (b) providing the exact file to
promote. Recommend a companion devkit PR under #1194.

## Validation

Local (worktree):

- `yamllint -c .yamllint --strict` on the new file — **pass**.
- `actionlint` (incl. embedded shellcheck of `run:` blocks) — **pass**.
- Full hook suite via the flake dev-shell (`nix develop --command just precommit`)
  — **all hooks pass/skip**.
- Repo test suite (`just test`) — **2 passed**.

Live on this PR (run [29813431342](https://github.com/vig-os/devkit-smoke-test/actions/runs/29813431342), all green):

- **fresh-install leg**: log shows `Installing Nix ... nix-2.35.1` — the
  `install-nix-action` branch executed.
- **preinstalled leg**: log shows `Host Nix present: ... (nix (Nix) 2.35.1)` and
  `Configured preinstalled host Nix via NIX_CONFIG.` — the #1192 detect/configure
  branch executed.
- Both legs: `Forwarded 30 dev-shell shellHook env var(s) to GITHUB_ENV.` — the
  #1189 forward ran, and the following steps (`Verify dev-shell toolchain`,
  `just sync`, `just precommit`) all succeeded off the forwarded env/PATH.

Two hosted-runner findings were fixed during iteration (both are themselves
useful smoke results about the `--docker` scaffold on a hosted runner):

1. The docker scaffold leaves the tree root-owned; `nix develop` could not write
   `flake.lock`. Fixed by an unconditional post-scaffold `chown`.
2. `install.sh`'s host-side git setup runs before that repair and fails on the
   root-owned tree with only a warning (`.git: Permission denied`), leaving no
   repository — `prek` then aborts. The lane now git-inits and commits the
   scaffold after the chown. (Possible upstream hardening: install.sh's git
   phase could fail loudly instead of warning — noting for devkit triage.)

Refs: [#1194](https://github.com/vig-os/devkit/issues/1194)
