### PR TITLE
chore: drift-gate red-path proof (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 # Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# DRIFT-PROOF: hand-edit of a managed file — this line must turn the scaffold-drift job red (devkit#1295 validation)
 # Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
 
 # CI Workflow (mode-aware)

--- a/.vig-os
+++ b/.vig-os
@@ -116,4 +116,4 @@ DEVKIT_UPGRADE_EXCLUDE=
 # construction (the scaffold never overwrites them). Pure runtime gate — CI reads
 # it via resolve-toolchain's `drift-check` output, so flipping it takes effect
 # with no re-scaffold; the value round-trips across `--force` upgrades (#1295).
-DEVKIT_DRIFT_CHECK=
+DEVKIT_DRIFT_CHECK=false


### PR DESCRIPTION
1.5.0-rc2 validation (devkit#1295): a hand-edited managed file must fail the scaffold-drift job. Second commit will flip DEVKIT_DRIFT_CHECK=false to prove the runtime opt-out. Will be closed unmerged.