### PR TITLE
chore: reset devkit pin to rc3 (devkit-upgrade live-proof harness)

### DIFF
--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.5.0
+DEVKIT_VERSION=1.5.0-rc3
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never

--- a/.vig-os
+++ b/.vig-os
@@ -116,4 +116,4 @@ DEVKIT_UPGRADE_EXCLUDE=
 # construction (the scaffold never overwrites them). Pure runtime gate — CI reads
 # it via resolve-toolchain's `drift-check` output, so flipping it takes effect
 # with no re-scaffold; the value round-trips across `--force` upgrades (#1295).
-DEVKIT_DRIFT_CHECK=
+DEVKIT_DRIFT_CHECK=false


### PR DESCRIPTION
Temporary one-line gap so the devkit-upgrade dispatch (vig-os/devkit#1302 Phase 4.6) exercises its push + PR legs with a real version delta. The resulting adoption PR restores DEVKIT_VERSION=1.5.0 — self-cleaning.