### PR TITLE
chore: pin-gap harness (verified-publish proof)

### DIFF
--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.5.0-rc4
+DEVKIT_VERSION=1.5.0-rc3
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never
@@ -116,4 +116,4 @@ DEVKIT_UPGRADE_EXCLUDE=
 # construction (the scaffold never overwrites them). Pure runtime gate — CI reads
 # it via resolve-toolchain's `drift-check` output, so flipping it takes effect
 # with no re-scaffold; the value round-trips across `--force` upgrades (#1295).
-DEVKIT_DRIFT_CHECK=
+DEVKIT_DRIFT_CHECK=false


### PR DESCRIPTION
Temporary rc3 pin so the devkit-upgrade dispatch (vig-os/devkit#1308) exercises the API publish leg with a real delta. The adoption PR restores the rc4 pin; the drift gate is re-enabled on that PR before merge. Self-cleaning.