### PR TITLE
fix(workflows): gate final release on human PR approval

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -614,17 +614,40 @@ jobs:
           gh pr edit "${PR_NUMBER}" --remove-label "release-kind:final" >/dev/null 2>&1 || true
           gh pr edit "${PR_NUMBER}" --add-label "${LABEL}"
 
-      - name: Approve release PR for automated dispatch
+      - name: Gate final release on human approval of release PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
           PR_NUMBER: ${{ steps.locate_release_pr.outputs.release_pr }}
+          PR_URL: ${{ steps.locate_release_pr.outputs.release_pr_url }}
+          RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
         run: |
           set -euo pipefail
-          gh pr review "${PR_NUMBER}" --approve \
-            --body "Automated approval by smoke-test dispatch orchestration." || {
-            echo "::error::Auto-approve failed. If you see a permissions error, enable repository (or organization) setting 'Allow GitHub Actions to create and approve pull requests'. See this PR description for context."
-            exit 1
-          }
+          # The org blocks workflow-token PR approvals (vig-os/org-config#122),
+          # and every dispatch recreates the release branch and PR from scratch,
+          # so an up-front human approval cannot survive to this point. Candidate
+          # dispatches follow the deferred-approval model (approval gates the
+          # final release only) and leave the PR unapproved; the final dispatch
+          # pauses here until a human approves the freshly created PR. See
+          # vig-os/devkit#1391.
+          if [ "${RELEASE_KIND}" != "final" ]; then
+            echo "Candidate dispatch: release PR #${PR_NUMBER} intentionally left unapproved (human approval gates the final release only)."
+            exit 0
+          fi
+          TIMEOUT=1800
+          INTERVAL=20
+          ELAPSED=0
+          echo "Final dispatch: waiting up to $((TIMEOUT / 60)) minutes for a human to approve release PR #${PR_NUMBER}: ${PR_URL}"
+          while [ "${ELAPSED}" -lt "${TIMEOUT}" ]; do
+            DECISION="$(gh pr view "${PR_NUMBER}" --json reviewDecision --jq '.reviewDecision // empty' 2>/dev/null || true)"
+            if [ "${DECISION}" = "APPROVED" ]; then
+              echo "Release PR #${PR_NUMBER} approved by a human reviewer."
+              exit 0
+            fi
+            sleep "${INTERVAL}"
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+          echo "::error::Timed out waiting for human approval of release PR #${PR_NUMBER} (${PR_URL}). Approve the PR, then re-run the failed jobs of this workflow run to resume the final release."
+          exit 1
 
   trigger-release:
     name: Trigger and wait for release workflow


### PR DESCRIPTION
Mirror of the devkit asset fix from vig-os/devkit#1392 (vig-os/devkit#1391), landed ahead of the rc4 dispatch: the listener executes from dev at trigger time, so the deploy PR alone cannot fix the in-flight run.

- Auto-approve step (blocked org-wide by vig-os/org-config#122) replaced with a kind-aware gate: candidates leave the release PR unapproved; the final dispatch polls up to 30 min for a human approval and fails with re-run guidance.
- Content is byte-identical to the rendered devkit asset on `release/1.7.0`, so the next deploy PR carries no listener diff.

Closes #341