### PR TITLE
fix(workflows): gate final release on human PR approval

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -320,7 +320,7 @@ jobs:
           fi
 
       - name: Commit and push deploy changes via signed commit-action
-        uses: vig-os/commit-action@3a0588ec060d9647bf406e064cf9e6192a431864  # v0.3.1
+        uses: vig-os/commit-action@0361e9aa65b64711a18286ac5dfdcba7cc7a2ac7  # v0.3.2
         env:
           GH_TOKEN: ${{ steps.generate_commit_token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -614,17 +614,40 @@ jobs:
           gh pr edit "${PR_NUMBER}" --remove-label "release-kind:final" >/dev/null 2>&1 || true
           gh pr edit "${PR_NUMBER}" --add-label "${LABEL}"
 
-      - name: Approve release PR for automated dispatch
+      - name: Gate final release on human approval of release PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
           PR_NUMBER: ${{ steps.locate_release_pr.outputs.release_pr }}
+          PR_URL: ${{ steps.locate_release_pr.outputs.release_pr_url }}
+          RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
         run: |
           set -euo pipefail
-          gh pr review "${PR_NUMBER}" --approve \
-            --body "Automated approval by smoke-test dispatch orchestration." || {
-            echo "::error::Auto-approve failed. If you see a permissions error, enable repository (or organization) setting 'Allow GitHub Actions to create and approve pull requests'. See this PR description for context."
-            exit 1
-          }
+          # The org blocks workflow-token PR approvals (vig-os/org-config#122),
+          # and every dispatch recreates the release branch and PR from scratch,
+          # so an up-front human approval cannot survive to this point. Candidate
+          # dispatches follow the deferred-approval model (approval gates the
+          # final release only) and leave the PR unapproved; the final dispatch
+          # pauses here until a human approves the freshly created PR. See
+          # vig-os/devkit#1391.
+          if [ "${RELEASE_KIND}" != "final" ]; then
+            echo "Candidate dispatch: release PR #${PR_NUMBER} intentionally left unapproved (human approval gates the final release only)."
+            exit 0
+          fi
+          TIMEOUT=1800
+          INTERVAL=20
+          ELAPSED=0
+          echo "Final dispatch: waiting up to $((TIMEOUT / 60)) minutes for a human to approve release PR #${PR_NUMBER}: ${PR_URL}"
+          while [ "${ELAPSED}" -lt "${TIMEOUT}" ]; do
+            DECISION="$(gh pr view "${PR_NUMBER}" --json reviewDecision --jq '.reviewDecision // empty' 2>/dev/null || true)"
+            if [ "${DECISION}" = "APPROVED" ]; then
+              echo "Release PR #${PR_NUMBER} approved by a human reviewer."
+              exit 0
+            fi
+            sleep "${INTERVAL}"
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+          echo "::error::Timed out waiting for human approval of release PR #${PR_NUMBER} (${PR_URL}). Approve the PR, then re-run the failed jobs of this workflow run to resume the final release."
+          exit 1
 
   trigger-release:
     name: Trigger and wait for release workflow


### PR DESCRIPTION
Hotfix to **main**: `repository_dispatch` executes the listener from the default branch, so the dev-side fix (#342) never ran — the rc4 chain (run 31217441944) still died at the retired auto-approve step, blocked org-wide by vig-os/org-config#122.

Byte-identical to the rendered devkit asset on `release/1.7.0` (vig-os/devkit#1392) and to dev after #342 (modulo the `vig-os/commit-action` v0.3.2 pin, which main had not yet received): candidate dispatches leave the fresh release PR unapproved; the final dispatch polls up to 30 min for a human approval. The upcoming smoke release merge to main carries the same content, so no divergence.

Refs: #341