### PR TITLE
fix(ci): mint notify App token for renamed devkit repo

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -1,7 +1,7 @@
 name: Repository Dispatch Listener
 #
 # Purpose:
-# - Handle cross-repo `repository_dispatch` events from vig-os/devcontainer.
+# - Handle cross-repo `repository_dispatch` events from vig-os/devkit.
 # - Deploy the requested tag into the smoke-test repo.
 # - Always create a `chore/deploy-<tag>` branch and PR to `dev`.
 # - Create signed deploy commits via `vig-os/commit-action`.
@@ -1035,7 +1035,7 @@ jobs:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: vig-os
-          repositories: devcontainer
+          repositories: devkit
 
       - name: Create upstream failure issue
         env:


### PR DESCRIPTION
Hot-deploy of the listener fix from vig-os/devkit#1398 directly to `main`, since the `repository_dispatch` listener executes from this repo's **default branch** — a fix that only rides the normal deploy path (next train's deploy PR to `dev`, then release to `main`) would not protect the very trains that fail.

The `notify-failure` job minted its upstream App token for the pre-rename `vig-os/devcontainer` repository; the App-installation lookup does not follow rename redirects, so every mint failed with 404 and no upstream failure issue was ever filed (all three 1.7.0-train listener failures).

`dev` is intentionally **not** patched: the next train's deploy PR carries the fixed asset from the devkit release tag and converges `dev` with identical content.

Will be live-proven with a synthetic failing dispatch (nonexistent tag) once merged.

Refs: vig-os/devkit#1396