### PR TITLE
chore(ci): make the deploy branch name dot-free

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -3,7 +3,9 @@ name: Repository Dispatch Listener
 # Purpose:
 # - Handle cross-repo `repository_dispatch` events from vig-os/devkit.
 # - Deploy the requested tag into the smoke-test repo.
-# - Always create a `chore/deploy-<tag>` branch and PR to `dev`.
+# - Always create a `chore/deploy-<tag-with-dashes>` branch (dots mapped to
+#   dashes: the scaffolded CI branch-name gate, vig-os/devkit#1432, and the
+#   local guard both reject dots in chore slugs) and PR to `dev`.
 # - Create signed deploy commits via `vig-os/commit-action`.
 # - CI (`ci.yml`) triggers on the deploy PR.
 #
@@ -304,7 +306,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          BRANCH_NAME="chore/deploy-${TAG}"
+          BRANCH_NAME="chore/deploy-${TAG//./-}"
           echo "branch_name=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
 
           DEV_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/dev" --jq '.object.sha')"


### PR DESCRIPTION
## Summary

One-line fix in the dispatch listener: `BRANCH_NAME="chore/deploy-${TAG}"` → `BRANCH_NAME="chore/deploy-${TAG//./-}"` (plus the header comment), so a deploy for tag `1.7.1-rc1` rides `chore/deploy-1-7-1-rc1` instead of `chore/deploy-1.7.1-rc1`.

## Why (pre-train prerequisite for devkit 1.7.1)

vig-os/devkit#1432 adds a **CI branch-name gate** to the scaffolded `ci.yml` commit-checks lane (folding in vig-os/devkit#1430). Dotted slugs fail both that gate and the local `chore/<slug>` convention — the same dot-free rule the devkit-upgrade lane branches already follow. Without this fix, the first 1.7.1 deploy PR would carry the new gate in its own diff and fail CI on its own branch name, blocking auto-merge and stalling the train at the smoke stage.

Targets **main** directly because `repository_dispatch` listeners run from the default branch — the fix must be live there before devkit dispatches the 1.7.1 candidate (precedent: #345, #353). `sync-main-to-dev` propagates it to `dev` after merge.

Nothing else consumes the branch name shape: the stale-PR cleanup keys on the `deploy` label, and `wait-deploy-merge` polls by PR URL.

## Verification

- Commit made in the dev-shell with all hooks green (incl. the branch-name and commit-message guards); SSH-signed (`sig:G`)
- Allowance check against the new devkit gate: `chore/deploy-1-7-1-rc1` matches `^chore/[a-z0-9]+(-[a-z0-9]+)*$`