### PR TITLE
fix(ci): reclaim deploy PRs by branch so a partial create stays recoverable

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -182,9 +182,20 @@ jobs:
             --description "Automated smoke-test deploy PRs" \
             --force
 
+          # Reclaim by head branch as well as by label (vig-os/devkit#1499).
+          # `gh pr create --label` labels in a SECOND mutation, so a transient
+          # there leaves an open, UNLABELLED deploy PR that a label-only query
+          # cannot see — and the documented re-run recovery then deadlocks on
+          # "a pull request already exists". The deploy branch name is
+          # deterministic and is pushed BEFORE the PR exists, so it is the one
+          # selector no partial failure can lose.
           mapfile -t OPEN_DEPLOY_PRS < <(
-            gh pr list --base dev --state open --label deploy \
-              --json number --jq '.[].number'
+            gh pr list --base dev --state open --limit 100 \
+              --json number,headRefName,labels \
+              --jq '.[]
+                    | select((.headRefName | startswith("chore/deploy-"))
+                             or (any(.labels[]; .name == "deploy")))
+                    | .number'
           )
 
           if [ "${#OPEN_DEPLOY_PRS[@]}" -eq 0 ]; then
@@ -403,13 +414,19 @@ jobs:
             -f sha="$COMMIT" -F force=true >/dev/null
           echo "Published ${#DELETED[@]} deletion(s) as ${COMMIT}."
 
-      - name: Create deploy PR
+      # Two mutations in one step is what broke the 1.9.0 rc1 deploy
+      # (vig-os/devkit#1499): `gh pr create --label` created the PR and then
+      # 500'd on the labelling, so the step exited 1 without ever writing
+      # pr_url and every downstream job skipped. Create (or adopt) here,
+      # record the url immediately, and label in a separate step.
+      - name: Create or adopt deploy PR
         id: create_pr
         env:
           GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
           TAG: ${{ needs.validate.outputs.tag }}
           BRANCH_NAME: ${{ steps.prepare_branch.outputs.branch_name }}
         run: |
+          set -euo pipefail
           PR_BODY="$(
             printf '%s\n' \
               "Automated smoke-test deployment commit created by repository_dispatch." \
@@ -419,15 +436,42 @@ jobs:
               "- Target: dev"
           )"
           PR_URL="$(
-            gh pr create \
-              --base dev \
-              --head "${BRANCH_NAME}" \
-              --title "chore: deploy ${TAG}" \
-              --body "${PR_BODY}" \
-              --label deploy
+            gh pr list --base dev --head "${BRANCH_NAME}" --state open \
+              --json url --jq '.[0].url // empty'
           )"
+          if [ -n "${PR_URL}" ]; then
+            echo "Adopted existing deploy PR: ${PR_URL}"
+          else
+            PR_URL="$(
+              gh pr create \
+                --base dev \
+                --head "${BRANCH_NAME}" \
+                --title "chore: deploy ${TAG}" \
+                --body "${PR_BODY}"
+            )"
+            echo "Created PR: ${PR_URL}"
+          fi
           echo "pr_url=${PR_URL}" >> "${GITHUB_OUTPUT}"
-          echo "Created PR: ${PR_URL}"
+
+      - name: Label deploy PR
+        id: label_pr
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+          PR_URL: ${{ steps.create_pr.outputs.pr_url }}
+        run: |
+          set -uo pipefail
+          # Advisory, not load-bearing: `Close stale deploy PRs` reclaims by
+          # head branch, so an unlabelled deploy PR stays recoverable. Retry
+          # the transient, then carry on rather than failing the deploy job
+          # and stranding pr_url (vig-os/devkit#1499).
+          for attempt in 1 2 3; do
+            if gh pr edit "${PR_URL}" --add-label deploy; then
+              exit 0
+            fi
+            echo "Labelling attempt ${attempt} failed; retrying..."
+            sleep $((attempt * 5))
+          done
+          echo "Warning: could not label ${PR_URL} -- the stale-PR cleanup reclaims it by branch"
 
       - name: Enable auto-merge
         env:
@@ -1279,8 +1323,21 @@ jobs:
           EOF
           )"
 
-          gh issue create \
-            --repo vig-os/devkit \
-            --title "Smoke-test dispatch failed for ${TAG:-unknown}" \
-            --label bug \
-            --body "${ISSUE_BODY}"
+          # This issue is the only signal left when the orchestration is
+          # already down, and it dies to the same transient class as everything
+          # it reports: on 1.9.0 rc1 it 500'd 20 s after the deploy did, so no
+          # incident was filed at all and vig-os/devkit#1499 had to be written
+          # by hand. Retry before giving up, and fail loudly if it never lands.
+          for attempt in 1 2 3; do
+            if gh issue create \
+              --repo vig-os/devkit \
+              --title "Smoke-test dispatch failed for ${TAG:-unknown}" \
+              --label bug \
+              --body "${ISSUE_BODY}"; then
+              exit 0
+            fi
+            echo "Issue creation attempt ${attempt} failed; retrying..."
+            sleep $((attempt * 5))
+          done
+          echo "ERROR: could not file the upstream failure issue"
+          exit 1


### PR DESCRIPTION
Hot-deploy of the listener fix from [vig-os/devkit#1505](https://github.com/vig-os/devkit/pull/1505) directly to `main`, since the `repository_dispatch` listener executes from this repo's **default branch** — a fix that only rides the normal deploy path (next train's deploy PR to `dev`, then release to `main`) would not protect the very trains that fail.

## What it fixes

On the 1.9.0 rc1 train the `deploy` job failed on a transient GraphQL 500 reading **`pull request update failed`** — *update*, not *create*. `gh pr create --label` creates the PR and labels it in a **second** mutation: the create had succeeded ([#367](https://github.com/vig-os/devkit-smoke-test/pull/367) existed), the labelling is what 500'd, and the step exited 1. So `pr_url` never reached `GITHUB_OUTPUT` (every downstream job skipped) and an **unlabelled** deploy PR was left open — invisible to a `Close stale deploy PRs` that selected on `--label deploy` alone. Re-running the failed jobs then deadlocked on *"a pull request already exists"* until the label was added by hand.

## Changes

1. Stale deploy PRs are reclaimed by **head branch** (`chore/deploy-*`) as well as by label. The branch name is deterministic and pushed before the PR exists, so no partial failure can lose it.
2. `Create or adopt deploy PR` adopts an open PR already on the deploy branch instead of failing on it, and records `pr_url` before anything else can fail.
3. Labelling moved to its own step: three attempts with backoff, non-fatal (the cleanup reclaims by branch, so an unlabelled PR stays recoverable).
4. `notify-failure` retries `gh issue create` — it died to the same transient 20 s later, so no upstream incident issue was filed at all and vig-os/devkit#1499 had to be written by hand.

## Provenance

The file is a byte-exact copy of the fixed devkit asset (`assets/smoke-test/.github/workflows/repository-dispatch.yml` on vig-os/devkit#1505), so the next scaffold deploy converges rather than reverts. Before this change the live listener on `main` was byte-identical to the devkit asset, so this PR carries only that fix — the same 72/15 diff.

`dev` is intentionally **not** patched: the next train's deploy PR carries the fixed asset from the devkit release tag and converges `dev` with identical content.

Tested upstream by `tests/test_smoke_deploy_pr_reclaim.py` (12 tests), which executes these steps' real bash against a stubbed `gh` — including the rc1 replay: an unlabelled deploy PR gets closed, and a labelling failure leaves `pr_url` recorded and the job green.

Refs: [#1499](https://github.com/vig-os/devkit/issues/1499)
